### PR TITLE
Recompile functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ flottekarte/extensions/libflottekarte.so
 subprojects/libprojwrap/
 flottekarte/extensions/src
 flottekarte/extensions/include
+flottekarte/extensions/subprojects
 flottekarte/extensions/meson.build

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-flottekarte
-=======
+FlotteKarte
+===========
 
-**flottekarte** is a Python library for quick and versatile cartography
+**FlotteKarte** is a Python library for quick and versatile cartography
 based on PROJ4-string syntax and using Matplotlib, NumPy, and PyPROJ under
 the hood.
 
@@ -15,16 +15,13 @@ pip install --user
 ```
 
 ### Recompiling the backend after an update to PROJ
-If the system's PROJ library is updated, FlotteKarte might be linked to a shared
-library that is no longer available on the system. Recompiling FlotteKarte will
-be necessary. This can be performed from within Python with the provided
-`recompile_flottekarte` function:
-```python
-from flottekarte import recompile_flottekarte
-recompile_flottekarte()
-```
-Afterwards, Python needs to be restarted to make the recompiled backend
-available.
+If the system's PROJ library is updated, FlotteKarte might be linked to a
+shared library that is no longer available on the system. Recompiling
+FlotteKarte will be necessary. This will automatically be performed at
+import time if a failure to load the shared library is detected.
+
+For this reason, Meson and Jinja need to be available on the system if the
+PROJ library that FlotteKarte is linked to changes.
 
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -14,16 +14,6 @@ A typical install might be performed by executing the following two commands
 pip install --user
 ```
 
-### Recompiling the backend after an update to PROJ
-If the system's PROJ library is updated, FlotteKarte might be linked to a
-shared library that is no longer available on the system. Recompiling
-FlotteKarte will be necessary. This will automatically be performed at
-import time if a failure to load the shared library is detected.
-
-For this reason, Meson and Jinja need to be available on the system if the
-PROJ library that FlotteKarte is linked to changes.
-
-
 ### Requirements
 The following software has to be installed:
  - PROJ
@@ -32,9 +22,21 @@ The following software has to be installed:
  - Matplotlib
  - PyProj
  - SciPy
+ - Meson
+ - Ninja
 
 The following software will be automatically downloaded during Meson installation:
  - [ProjWrapCpp](https://github.com/mjziebarth/ProjWrapCpp)
+
+### Recompiling the backend after an update to PROJ
+If the system's PROJ library is updated, FlotteKarte might be linked to a
+shared library that is no longer available on the system. Recompiling
+FlotteKarte will be necessary. This will automatically be performed at
+import time if a failure to load the shared library is detected.
+
+For this reason, Meson and Ninja need to be available on the system if the
+PROJ library that FlotteKarte is linked to changes.
+
 
 ## Usage
 FlotteKarte is a low-overhead plotting routine. The conceptual idea behind this package

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [Unreleased]
 #### Added
 - Guard against non-identical version numbers across the project.
+- Outsource the `flottekarte` shared object loading check to a subprocess
+- Automatic recompilation of the shared object if loading fails.
 
 ### [0.2.2] - 2022-08-05
 #### Added

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ A typical install might be performed by executing the following two commands
 pip install --user
 ```
 
+### Recompiling the backend after an update to PROJ
+If the system's PROJ library is updated, FlotteKarte might be linked to a shared
+library that is no longer available on the system. Recompiling FlotteKarte will
+be necessary. This can be performed from within Python with the provided
+`recompile_flottekarte` function:
+```python
+from flottekarte import recompile_flottekarte
+recompile_flottekarte()
+```
+Afterwards, Python needs to be restarted to make the recompiled backend
+available.
+
+
 ### Requirements
 The following software has to be installed:
  - PROJ

--- a/compile.sh
+++ b/compile.sh
@@ -29,6 +29,11 @@ if [ ! -d flottekarte/extensions/src/ ]; then
     ln -s ../../src
     cd ../..
 fi
+if [ ! -d flottekarte/extensions/subprojects/ ]; then
+    cd flottekarte/extensions/
+    ln -s ../../subprojects
+    cd ../..
+fi
 if [ ! -f flottekarte/extensions/meson.build ]; then
     cd flottekarte/extensions
     ln -s ../../meson.build

--- a/flottekarte/__init__.py
+++ b/flottekarte/__init__.py
@@ -19,3 +19,4 @@
 
 from .map import Map
 from .data import GeoJSON
+from .extensions.cdll import recompile_flottekarte

--- a/flottekarte/extensions/cdll.py
+++ b/flottekarte/extensions/cdll.py
@@ -17,17 +17,71 @@
 # See the Licence for the specific language governing permissions and
 # limitations under the Licence.
 
+import os
 import pathlib
+import subprocess
 import numpy as np
 from ctypes import CDLL
+from shutil import copyfile
+from warnings import warn
 
 # Load the shared library:
-_cdll_path = pathlib.Path(__file__).parent / 'libflottekarte.so'
+_parent_directory = pathlib.Path(__file__).parent
+_cdll_path = _parent_directory / 'libflottekarte.so'
 try:
     _cdll = CDLL(_cdll_path)
 except OSError:
+    _cdll = None
     raise ImportError("Could not load the compiled backend "
                       "'libflottekarte.so'. Most likely this means that your "
                       "system library has been updated and you need to "
-                      "recompile the FlotteKarte backend. You can do so by "
-                      "reinstalling the package.")
+                      "recompile the FlotteKarte backend. You can do so from "
+                      "within Python by importing and calling the function "
+                      "`flottekarte.recompile_flottekarte`. Afterwards, "
+                      "restarting Python will be necessary.")
+
+
+# Recompilation facility:
+def recompile_flottekarte():
+    """
+    Recompile the C++ backend and link against updated PROJ system
+    library.
+    """
+    global _cdll
+    if _cdll is not None:
+        warn("Recompiling with a loaded backend can lead to a Python crash. "
+             "Please restart Python after the compilation was successful.")
+    else:
+        _cdll = None
+
+    # Current directory:
+    current_dir = pathlib.Path.cwd().absolute()
+
+    # Path to this file. In the parent directory, we should find copies
+    # of the `include` and `src` folders.
+    include = _parent_directory / "include"
+    src = _parent_directory / "src"
+    subproj = _parent_directory / "subprojects"
+    if not include.is_dir() or not src.is_dir() or not subproj.is_dir():
+        raise RuntimeError("One of the source directories has not been "
+                           "copied to the extension path. Cannot compile.")
+    if not (_parent_directory / "meson.build").is_file():
+        raise RuntimeError("Did not find `meson.build` file in extension "
+                           "path.")
+
+    # Change to the extension path:
+    os.chdir(_parent_directory)
+
+    # Perform Meson build:
+    subprocess.run(["meson","setup","builddir"], check=True)
+    subprocess.run(["meson","compile","-C","builddir"], check=True)
+
+    # Copy the compiled library:
+    copyfile((_parent_directory / "builddir" / "libflottekarte.so").absolute(),
+             (_parent_directory / "libflottekarte.so").absolute())
+
+    # Ensure that we do not try to access any loaded CDLL:
+    _cdll = None
+
+    # Change back to working directory:
+    os.chdir(current_dir)

--- a/flottekarte/extensions/test-cdll.py
+++ b/flottekarte/extensions/test-cdll.py
@@ -1,8 +1,10 @@
-# FlotteKarte initialization module.
+#!/bin/python
+# This script checks whether the compiled backend `libflottekarte.so`
+# can be loaded (or, alternatively, if there is a linking error).
 #
 # Authors: Malte J. Ziebarth (ziebarth@gfz-potsdam.de)
 #
-# Copyright (C) 2022 Deutsches GeoForschungsZentrum Potsdam
+# Copyright (C) 2022 Malte J. Ziebarth
 #
 # Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
 # the European Commission - subsequent versions of the EUPL (the "Licence");
@@ -17,6 +19,14 @@
 # See the Licence for the specific language governing permissions and
 # limitations under the Licence.
 
-from .extensions.cdll import recompile_flottekarte
-from .map import Map
-from .data import GeoJSON
+import pathlib
+from ctypes import CDLL
+
+# Load the shared library:
+_parent_directory = pathlib.Path(__file__).parent
+_cdll_path = _parent_directory / 'libflottekarte.so'
+try:
+    CDLL(_cdll_path)
+except OSError:
+    raise ImportError("Could not load the compiled backend "
+                      "'libflottekarte.so'.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,4 +23,5 @@ packages = ["flottekarte","flottekarte.extensions","flottekarte.data"]
 
 [tool.setuptools.package-data]
 flottekarte = ["extensions/libflottekarte.so", "extensions/meson.build",
-               "extensions/include/*", "extensions/src/*"]
+               "extensions/include/*", "extensions/src/*",
+               "extensions/subprojects/*"]


### PR DESCRIPTION
This code change adds an automatic check at import time, separated in a subprocess, that checks whether the C++ backend shared object can be loaded with `ctypes`.

If not, the C++ backend is automatically recompiled at import time.